### PR TITLE
Prevent booking overlap

### DIFF
--- a/emhub/data/content/dc_sessions.py
+++ b/emhub/data/content/dc_sessions.py
@@ -194,7 +194,7 @@ def register_content(dc):
         d30 = dt.timedelta(days=30)
 
         for s in all_sessions:
-            if now - s.start > d30:
+            if s.start is not None and now - s.start > d30:
                 continue
 
             if s.booking:

--- a/emhub/data/data_models.py
+++ b/emhub/data/data_models.py
@@ -892,7 +892,7 @@ def create_data_models(dm):
             if strict:
                 return s <= b.start <= e or s <= b.end <= e
             else:
-                return s < b.start < e or s < b.end < e
+                return s <= b.start < e or s < b.end <= e
 
         def inside_slot(self, b):
             """ Check if the current booking is contained inside another


### PR DESCRIPTION
Updates the overlap() method of the Booking model to prevent certain overlaps where one booking's range is entirely contained in the other's, and the two either start or end at exactly the same time (or both).

Fixes #118