### PR TITLE
Fix JWT token generation for PyJWT >= 2.0

### DIFF
--- a/emhub/data/data_models.py
+++ b/emhub/data/data_models.py
@@ -260,7 +260,7 @@ def create_data_models(dm):
             token = jwt.encode(
                 {'reset_password': self.id,
                  'exp': dm.now() + dt.timedelta(seconds=expires_in)},
-                app.config['SECRET_KEY'], algorithm='HS256').decode('utf-8')
+                app.config['SECRET_KEY'], algorithm='HS256')
             self.reset_token = token
 
             return token


### PR DESCRIPTION
Removes the unnecessary `.decode("utf-8")` call when generating JWT tokens. In PyJWT versions >= 2.0, `jwt.encode()` already returns a `str` instead of `bytes`. Attempting to decode it causes an `AttributeError: 'str' object has no attribute 'decode'`.