### PR TITLE
Update data_models.py

### DIFF
--- a/emhub/data/data_models.py
+++ b/emhub/data/data_models.py
@@ -1031,7 +1031,7 @@ def create_data_models(dm):
 
         @property
         def owner_id(self):
-            return self.booking.owner_id if self.booking else None
+            return dm.get_booking_by(id=self.booking_id).owner_id if self.booking_id else None
 
         @property
         def owner(self):


### PR DESCRIPTION
Prevent error when trying to remove a session. Before it was failing with the error:

> Traceback: Traceback (most recent call last):
  File "/mnt/cryoemgfs/data/software/emhub/emhub/blueprints/api.py", line 1107, in _handle_item
    result = handle_func(**attrs)
  File "/mnt/cryoemgfs/data/software/emhub/emhub/blueprints/api.py", line 1172, in handle
    return session_func(**attrs).json()
  File "/mnt/cryoemgfs/data/software/emhub/emhub/data/data_models.py", line 1099, in json
    json['owner_id'] = self.owner_id or 'None'
  File "/mnt/cryoemgfs/data/software/emhub/emhub/data/data_models.py", line 1034, in owner_id
    return self.booking.owner_id if self.booking else None
  File "/software/miniforge3_envs/emhub/lib/python3.8/site-packages/sqlalchemy/orm/attributes.py", line 565, in __get__
    return self.impl.get(state, dict_)  # type: ignore[no-any-return]
  File "/software/miniforge3_envs/emhub/lib/python3.8/site-packages/sqlalchemy/orm/attributes.py", line 1085, in get
    value = self._fire_loader_callables(state, key, passive)
  File "/software/miniforge3_envs/emhub/lib/python3.8/site-packages/sqlalchemy/orm/attributes.py", line 1120, in _fire_loader_callables
    return self.callable_(state, passive)
  File "/software/miniforge3_envs/emhub/lib/python3.8/site-packages/sqlalchemy/orm/strategies.py", line 917, in _load_for_state
    raise orm_exc.DetachedInstanceError(
sqlalchemy.orm.exc.DetachedInstanceError: Parent instance  is not bound to a Session; lazy load operation of attribute 'booking' cannot proceed (Background on this erro rat: https://sqlalche.me/e/20/bhk3)